### PR TITLE
Cryptsy has updated the security layer

### DIFF
--- a/CryptsyAPI/CryptsyAPI.cs
+++ b/CryptsyAPI/CryptsyAPI.cs
@@ -384,10 +384,14 @@ namespace Cryptsy
             }
 
 
-
-            var request = WebRequest.Create(new Uri(url));
+            // To handle cookies we needed a HttpWebRequest instead of a WebRequest
+            HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(new Uri(url));
             if (request == null)
                 throw new Exception("Non HTTP WebRequest");
+
+            // Add cookie handling for the request
+            CookieContainer cookieJar = new CookieContainer();
+            request.CookieContainer = cookieJar;
 
             if (authenticate)
             {


### PR DESCRIPTION
Cryptsy has updated the security layer so the API client needs to support cookies, so i changed from WebRequest to HttpWebRequest and added a CookieContainer to handle this.

Security Note from Cryptsy: "Since implementation of our new security layer, some API clients are getting denied access. If possible, you should program your bot to accept cookies to pass the security test. If you are still unable to connect, then contact us with your IP address so that we may whitelist your application."
